### PR TITLE
Zuora signature generation code

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,3 +55,6 @@ Style/AlignParameters:
 
 Style/SignalException:
   EnforcedStyle: only_raise
+
+Style/NumericLiterals:
+  Enabled: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,3 +248,6 @@ DEPENDENCIES
   timecop
   web-console (~> 2.0)
   webmock
+
+BUNDLED WITH
+   1.10.3

--- a/app/controllers/zuora_controller.rb
+++ b/app/controllers/zuora_controller.rb
@@ -1,0 +1,59 @@
+class ZuoraController < ApplicationController
+
+  class ZuoraConnectionError < StandardError; end
+
+  def create_hmac_signature
+    data = signature_request(params)
+
+    if data[:success]
+      render json: { signature: data[:signature], token: data[:token], cookie: zuora_session }
+    else
+      render json: { reasons: data[:reasons] }, status: 422
+    end
+  rescue ZuoraConnectionError
+    render nothing: true, status: 502
+  end
+
+  private
+
+    def zuora_session
+      @_session ||= begin
+        response = session_request
+        if response.code == 200
+          cookie_header = response.headers['set-cookie']
+          cookie_header.match(/(ZSession=.*?);/)[1]
+        else
+          raise ZuoraConnectionError.new
+        end
+      end
+    end
+
+    def signature_request(params)
+      HTTParty.post('https://apisandbox-api.zuora.com/rest/v1/hmac-signatures', headers: {
+        'Cookie'             => zuora_session,
+        'Accept'             => 'application/json',
+        'Content-Type'       => 'application/json',
+        'apiAccessKeyId'     => Rails.configuration.x.zuora.api_key,
+        'apiSecretAccessKey' => Rails.configuration.x.zuora.api_secret
+      }, body: signature_request_body(params)).parsed_response.symbolize_keys
+    end
+
+    def signature_request_body(params)
+      body = {
+        uri:    params[:uri],
+        method: params[:method].upcase
+      }.merge(params[:params])
+      JSON.generate(body)
+    end
+
+    def session_request
+      HTTParty.post(
+        'https://apisandbox-api.zuora.com/rest/v1/connections',
+        headers: {
+          'apiAccessKeyId'     => Rails.configuration.x.zuora.api_key,
+          'apiSecretAccessKey' => Rails.configuration.x.zuora.api_secret
+        }
+      )
+    end
+
+end

--- a/config/initializers/zuora.rb
+++ b/config/initializers/zuora.rb
@@ -1,0 +1,9 @@
+if Rails.env.test?
+  Rails.application.config.x.zuora.api_key    = 'ZUORA_API_KEY'
+  Rails.application.config.x.zuora.api_secret = 'ZUORA_API_SECRET'
+else
+  Rails.application.config.x.zuora.api_key    = ENV['ZUORA_API_KEY']
+  Rails.application.config.x.zuora.api_secret = ENV['ZUORA_API_SECRET']
+end
+
+Rails.application.config.x.zuora.api_url    = 'https://apisandbox-api.zuora.com'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
   post 'token', to: 'oauth2#create'
   post 'revoke', to: 'oauth2#destroy'
+
+  post 'zuora-signatures', to: 'zuora#create_hmac_signature'
 end

--- a/spec/controllers/zuora_controller_spec.rb
+++ b/spec/controllers/zuora_controller_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+describe ZuoraController do
+  describe 'POST #create_hmac_signature' do
+    before do
+      stub_request(:post, %r{#{Rails.configuration.x.zuora.api_url}/rest/v1/connections}).to_return(headers: { 'set-cookie' => 'ZSession=cookie;' })
+      stub_request(:post, %r{#{Rails.configuration.x.zuora.api_url}/rest/v1/hmac-signatures}).to_return(
+        body: JSON.generate(
+          { signature: 'signature', token: 'token', success: true }
+        ),
+        headers: { 'Content-Type' => 'application/json' }
+      )
+    end
+
+    subject do
+      post :create_hmac_signature, {
+        uri: 'https://apisandbox.zuora.com/rest/v1/payment-methods/credit-cards',
+        method: 'POST',
+        params: { some: 'value' }
+      }
+    end
+
+    it 'succeeds' do
+      subject
+
+      expect(response).to have_http_status(200)
+    end
+
+    it 'responds with an access token' do
+      subject
+
+      expect(JSON.parse(response.body).symbolize_keys).to eql({ signature: 'signature', token: 'token', cookie: 'ZSession=cookie' })
+    end
+
+    context 'when authentication against Zuora fails' do
+      before do
+        stub_request(:post, %r{#{Rails.configuration.x.zuora.api_url}/rest/v1/connections}).to_return(status: 401)
+      end
+
+      it 'responds with status 502' do
+        subject
+
+        expect(response).to have_http_status(502)
+      end
+    end
+
+    context 'when requesting the signature fails' do
+      before do
+        stub_request(:post, %r{#{Rails.configuration.x.zuora.api_url}/rest/v1/hmac-signatures}).to_return(
+          body: JSON.generate(
+            { reasons: [{ message: 'message', code: 12345 }], success: false }
+          ),
+          headers: { 'Content-Type' => 'application/json' }
+        )
+      end
+
+      it 'responds with status 422' do
+        subject
+
+        expect(response).to have_http_status(422)
+      end
+
+      it 'responds with the Zuora errors' do
+        subject
+
+        expect(JSON.parse(response.body).deep_symbolize_keys).to eql({ reasons: [{ message: 'message', code: 12345 }] })
+      end
+    end
+  end
+end

--- a/spec/routing/zuora_signatures_spec.rb
+++ b/spec/routing/zuora_signatures_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+describe 'Zuora routes' do
+  it 'routes to the Zuora CORS signature route' do
+    expect(post: '/zuora-signatures').to route_to(
+      controller: 'zuora', action: 'create_hmac_signature'
+    )
+  end
+end


### PR DESCRIPTION
This adds code for generating Zuora request signatures to use in the frontend for making requests against the Zuora API. While this isn't really auth related it might be helpful for a lot of people.
